### PR TITLE
FISH-6885 Cherry-pick Null Check to Tyrus 2.1.3

### DIFF
--- a/archetypes/echo/pom.xml
+++ b/archetypes/echo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.archetypes</groupId>
         <artifactId>tyrus-archetypes-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <description>

--- a/archetypes/echo/pom.xml
+++ b/archetypes/echo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.archetypes</groupId>
         <artifactId>tyrus-archetypes-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <description>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.archetypes</groupId>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.archetypes</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.glassfish.tyrus</groupId>
     <artifactId>tyrus-bom</artifactId>
-    <version>2.1.3.payara-p1</version>
+    <version>2.1.3.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Tyrus BOM</name>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.glassfish.tyrus</groupId>
     <artifactId>tyrus-bom</artifactId>
-    <version>2.1.3.payara-p1-SNAPSHOT</version>
+    <version>2.1.3.payara-p1</version>
     <packaging>pom</packaging>
     <name>Tyrus BOM</name>
 

--- a/bundles/client-jdk/pom.xml
+++ b/bundles/client-jdk/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/bundles/client-jdk/pom.xml
+++ b/bundles/client-jdk/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/bundles/client/pom.xml
+++ b/bundles/client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/bundles/client/pom.xml
+++ b/bundles/client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.bundles</groupId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.bundles</groupId>

--- a/bundles/samples/pom.xml
+++ b/bundles/samples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tyrus-samples</artifactId>

--- a/bundles/samples/pom.xml
+++ b/bundles/samples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <artifactId>tyrus-samples</artifactId>

--- a/bundles/websocket-ri-archive/pom.xml
+++ b/bundles/websocket-ri-archive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>websocket-ri-archive</artifactId>

--- a/bundles/websocket-ri-archive/pom.xml
+++ b/bundles/websocket-ri-archive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <artifactId>websocket-ri-archive</artifactId>

--- a/bundles/websocket-ri-bundle/pom.xml
+++ b/bundles/websocket-ri-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>websocket-ri-bundle</artifactId>

--- a/bundles/websocket-ri-bundle/pom.xml
+++ b/bundles/websocket-ri-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-bundles</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <artifactId>websocket-ri-bundle</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/glassfish/cdi/pom.xml
+++ b/containers/glassfish/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-glassfish-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/glassfish/cdi/pom.xml
+++ b/containers/glassfish/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-glassfish-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/glassfish/ejb/pom.xml
+++ b/containers/glassfish/ejb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-glassfish-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/glassfish/ejb/pom.xml
+++ b/containers/glassfish/ejb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-glassfish-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/glassfish/pom.xml
+++ b/containers/glassfish/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/glassfish/pom.xml
+++ b/containers/glassfish/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/grizzly-client/pom.xml
+++ b/containers/grizzly-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/grizzly-client/pom.xml
+++ b/containers/grizzly-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/grizzly-server/pom.xml
+++ b/containers/grizzly-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/grizzly-server/pom.xml
+++ b/containers/grizzly-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/inmemory/pom.xml
+++ b/containers/inmemory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/inmemory/pom.xml
+++ b/containers/inmemory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/jdk-client/pom.xml
+++ b/containers/jdk-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/jdk-client/pom.xml
+++ b/containers/jdk-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/servlet/pom.xml
+++ b/containers/servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/servlet/pom.xml
+++ b/containers/servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-containers-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletContainerInitializer.java
+++ b/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletContainerInitializer.java
@@ -76,6 +76,11 @@ public class TyrusServletContainerInitializer implements ServletContainerInitial
             return;
         }
 
+        if (ctx.getAttribute(ServerContainer.class.getName()) != null) {
+            // Already initialized
+            return;
+        }
+
         classes.removeAll(FILTERED_CLASSES);
 
         final Integer incomingBufferSize = getIntContextParam(ctx, TyrusHttpUpgradeHandler.FRAME_BUFFER_SIZE);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tyrus-documentation</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <artifactId>tyrus-documentation</artifactId>

--- a/ext/client-cli/pom.xml
+++ b/ext/client-cli/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/client-cli/pom.xml
+++ b/ext/client-cli/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/client-java8/pom.xml
+++ b/ext/client-java8/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/client-java8/pom.xml
+++ b/ext/client-java8/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/extension-deflate/pom.xml
+++ b/ext/extension-deflate/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/extension-deflate/pom.xml
+++ b/ext/extension-deflate/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/monitoring-jmx/pom.xml
+++ b/ext/monitoring-jmx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <artifactId>tyrus-monitoring-jmx</artifactId>

--- a/ext/monitoring-jmx/pom.xml
+++ b/ext/monitoring-jmx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.ext</groupId>
         <artifactId>tyrus-extensions-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tyrus-monitoring-jmx</artifactId>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.glassfish.tyrus</groupId>
     <artifactId>tyrus-project</artifactId>
-    <version>2.1.3.payara-p1</version>
+    <version>2.1.3.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>tyrus</name>
     <description>Tyrus is the reference implementation of Java API for WebSocket (JSR-356)</description>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.glassfish.tyrus</groupId>
     <artifactId>tyrus-project</artifactId>
-    <version>2.1.3.payara-p1-SNAPSHOT</version>
+    <version>2.1.3.payara-p1</version>
     <packaging>pom</packaging>
     <name>tyrus</name>
     <description>Tyrus is the reference implementation of Java API for WebSocket (JSR-356)</description>

--- a/samples/auction/pom.xml
+++ b/samples/auction/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/auction/pom.xml
+++ b/samples/auction/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/cdi/pom.xml
+++ b/samples/cdi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/cdi/pom.xml
+++ b/samples/cdi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/chat/pom.xml
+++ b/samples/chat/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/chat/pom.xml
+++ b/samples/chat/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/draw/pom.xml
+++ b/samples/draw/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/draw/pom.xml
+++ b/samples/draw/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/echo-basic-auth/pom.xml
+++ b/samples/echo-basic-auth/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/echo-basic-auth/pom.xml
+++ b/samples/echo-basic-auth/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/echo-https/pom.xml
+++ b/samples/echo-https/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/echo-https/pom.xml
+++ b/samples/echo-https/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/echo/pom.xml
+++ b/samples/echo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/echo/pom.xml
+++ b/samples/echo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.samples</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.samples</groupId>

--- a/samples/programmatic-echo/pom.xml
+++ b/samples/programmatic-echo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/programmatic-echo/pom.xml
+++ b/samples/programmatic-echo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/shared-collection/pom.xml
+++ b/samples/shared-collection/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/shared-collection/pom.xml
+++ b/samples/shared-collection/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/simplelife/pom.xml
+++ b/samples/simplelife/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/samples/simplelife/pom.xml
+++ b/samples/simplelife/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.samples</groupId>
         <artifactId>tyrus-samples-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/containers/jdk-client/pom.xml
+++ b/tests/containers/jdk-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-containers</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/containers/jdk-client/pom.xml
+++ b/tests/containers/jdk-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-containers</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/containers/pom.xml
+++ b/tests/containers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/containers/pom.xml
+++ b/tests/containers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/containers/servlet/pom.xml
+++ b/tests/containers/servlet/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-containers</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/containers/servlet/pom.xml
+++ b/tests/containers/servlet/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-containers</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/application-config/pom.xml
+++ b/tests/e2e/application-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/application-config/pom.xml
+++ b/tests/e2e/application-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/jdk8/pom.xml
+++ b/tests/e2e/jdk8/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/jdk8/pom.xml
+++ b/tests/e2e/jdk8/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/jetty/auth-basic/pom.xml
+++ b/tests/e2e/jetty/auth-basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e-jetty</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/tests/e2e/jetty/auth-basic/pom.xml
+++ b/tests/e2e/jetty/auth-basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e-jetty</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/tests/e2e/jetty/auth-digest/pom.xml
+++ b/tests/e2e/jetty/auth-digest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e-jetty</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/tests/e2e/jetty/auth-digest/pom.xml
+++ b/tests/e2e/jetty/auth-digest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e-jetty</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/tests/e2e/jetty/pom.xml
+++ b/tests/e2e/jetty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/e2e/jetty/pom.xml
+++ b/tests/e2e/jetty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/e2e/non-deployable/pom.xml
+++ b/tests/e2e/non-deployable/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/non-deployable/pom.xml
+++ b/tests/e2e/non-deployable/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/e2e/standard-config/pom.xml
+++ b/tests/e2e/standard-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/e2e/standard-config/pom.xml
+++ b/tests/e2e/standard-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-e2e</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.tests</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus</groupId>
         <artifactId>tyrus-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.tests</groupId>

--- a/tests/qa/browser-test/pom.xml
+++ b/tests/qa/browser-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.qa</groupId>
         <artifactId>tyrus-tests-qa-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/qa/browser-test/pom.xml
+++ b/tests/qa/browser-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.qa</groupId>
         <artifactId>tyrus-tests-qa-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/qa/lifecycle-test/pom.xml
+++ b/tests/qa/lifecycle-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.qa</groupId>
         <artifactId>tyrus-tests-qa-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/qa/lifecycle-test/pom.xml
+++ b/tests/qa/lifecycle-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.qa</groupId>
         <artifactId>tyrus-tests-qa-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/qa/pom.xml
+++ b/tests/qa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.tests.qa</groupId>

--- a/tests/qa/pom.xml
+++ b/tests/qa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.tests.qa</groupId>

--- a/tests/servlet/async/pom.xml
+++ b/tests/servlet/async/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/async/pom.xml
+++ b/tests/servlet/async/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/autobahn-server/pom.xml
+++ b/tests/servlet/autobahn-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/autobahn-server/pom.xml
+++ b/tests/servlet/autobahn-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/basic/pom.xml
+++ b/tests/servlet/basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/basic/pom.xml
+++ b/tests/servlet/basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/debug/pom.xml
+++ b/tests/servlet/debug/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>tyrus-tests-servlet-project</artifactId>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/servlet/debug/pom.xml
+++ b/tests/servlet/debug/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>tyrus-tests-servlet-project</artifactId>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/servlet/dynamic-deploy/pom.xml
+++ b/tests/servlet/dynamic-deploy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/dynamic-deploy/pom.xml
+++ b/tests/servlet/dynamic-deploy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/embedded-glassfish-test/pom.xml
+++ b/tests/servlet/embedded-glassfish-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/embedded-glassfish-test/pom.xml
+++ b/tests/servlet/embedded-glassfish-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/inject/pom.xml
+++ b/tests/servlet/inject/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/inject/pom.xml
+++ b/tests/servlet/inject/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/maxsessions-per-app/pom.xml
+++ b/tests/servlet/maxsessions-per-app/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/maxsessions-per-app/pom.xml
+++ b/tests/servlet/maxsessions-per-app/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/maxsessions-per-remoteaddr/pom.xml
+++ b/tests/servlet/maxsessions-per-remoteaddr/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/maxsessions-per-remoteaddr/pom.xml
+++ b/tests/servlet/maxsessions-per-remoteaddr/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/mbean/pom.xml
+++ b/tests/servlet/mbean/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/mbean/pom.xml
+++ b/tests/servlet/mbean/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/noappconfig/pom.xml
+++ b/tests/servlet/noappconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/noappconfig/pom.xml
+++ b/tests/servlet/noappconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/oneappconfig/pom.xml
+++ b/tests/servlet/oneappconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/oneappconfig/pom.xml
+++ b/tests/servlet/oneappconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/pom.xml
+++ b/tests/servlet/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.tests.servlet</groupId>

--- a/tests/servlet/pom.xml
+++ b/tests/servlet/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.tyrus.tests.servlet</groupId>

--- a/tests/servlet/remote-endpoint-timeout/pom.xml
+++ b/tests/servlet/remote-endpoint-timeout/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/remote-endpoint-timeout/pom.xml
+++ b/tests/servlet/remote-endpoint-timeout/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/session/pom.xml
+++ b/tests/servlet/session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/session/pom.xml
+++ b/tests/servlet/session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/twoappconfig/pom.xml
+++ b/tests/servlet/twoappconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/servlet/twoappconfig/pom.xml
+++ b/tests/servlet/twoappconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests.servlet</groupId>
         <artifactId>tyrus-tests-servlet-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <packaging>war</packaging>

--- a/tests/tools/pom.xml
+++ b/tests/tools/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1-SNAPSHOT</version>
+        <version>2.1.3.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/tools/pom.xml
+++ b/tests/tools/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.tyrus.tests</groupId>
         <artifactId>tyrus-tests-project</artifactId>
-        <version>2.1.3.payara-p1</version>
+        <version>2.1.3.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Title.

Note that the `ServerExecutorsManagementTest` is _extremely_ flakey - I recommend using `-fae` or skipping tests.
This is not something we've broken, you get the same behaviour on vanilla 2.1.3.